### PR TITLE
[Update] Bump root to v0.1.1

### DIFF
--- a/contracts/batcher/Batcher.sol
+++ b/contracts/batcher/Batcher.sol
@@ -1,10 +1,10 @@
 //SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.11;
+pragma solidity 0.8.13;
 
-import "@equilibria/root/types/UFixed18.sol";
-import "@equilibria/root/types/Token18.sol";
-import "@equilibria/root/types/Token6.sol";
-import "@equilibria/root/unstructured/UOwnable.sol";
+import "@equilibria/root/number/types/UFixed18.sol";
+import "@equilibria/root/token/types/Token18.sol";
+import "@equilibria/root/token/types/Token6.sol";
+import "@equilibria/root/control/unstructured/UOwnable.sol";
 import "../interfaces/IBatcher.sol";
 
 abstract contract Batcher is IBatcher, UOwnable {
@@ -24,7 +24,7 @@ abstract contract Batcher is IBatcher, UOwnable {
         DSU.approve(address(RESERVE));
         USDC.approve(address(RESERVE));
 
-        UOwnable__initialize();
+        __UOwnable__initialize();
     }
 
     function totalBalance() public view returns (UFixed18) {

--- a/contracts/batcher/WrapOnlyBatcher.sol
+++ b/contracts/batcher/WrapOnlyBatcher.sol
@@ -1,9 +1,9 @@
 //SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.11;
+pragma solidity 0.8.13;
 
-import "@equilibria/root/types/UFixed18.sol";
-import "@equilibria/root/types/Token18.sol";
-import "@equilibria/root/types/Token6.sol";
+import "@equilibria/root/number/types/UFixed18.sol";
+import "@equilibria/root/token/types/Token18.sol";
+import "@equilibria/root/token/types/Token6.sol";
 import "./Batcher.sol";
 
 contract WrapOnlyBatcher is Batcher {

--- a/contracts/interfaces/IBatcher.sol
+++ b/contracts/interfaces/IBatcher.sol
@@ -1,7 +1,7 @@
 //SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
 
-import "@equilibria/root/types/UFixed18.sol";
+import "@equilibria/root/number/types/UFixed18.sol";
 
 interface IBatcher {
     event Wrap(address indexed to, UFixed18 amount);

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@equilibria/emptyset-batcher",
   "description": "Batch wrapping contracts for the Empty Set protocol.",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "files": [
     "/interfaces/**/*.sol",
     "/batcher/Batcher.sol"

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -113,7 +113,7 @@ const config: HardhatUserConfig = {
   solidity: {
     compilers: [
       {
-        version: '0.8.11',
+        version: '0.8.13',
         settings: {
           optimizer: {
             enabled: false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "emptyset-wrapper",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -25,14 +25,14 @@
   "license": "APACHE-2.0",
   "devDependencies": {
     "@codechecks/client": "^0.1.10",
-    "@equilibria/root": "0.0.2",
+    "@equilibria/root": "0.1.1",
     "@ethersproject/abi": "^5.3.1",
     "@ethersproject/bytes": "^5.0.0",
     "@ethersproject/providers": "^5.3.1",
     "@nomiclabs/hardhat-ethers": "^2.0.1",
     "@nomiclabs/hardhat-etherscan": "^2.1.1",
     "@nomiclabs/hardhat-waffle": "^2.0.0",
-    "@openzeppelin/contracts": "4.4.1",
+    "@openzeppelin/contracts": "4.5.0",
     "@typechain/ethers-v5": "^7.0.1",
     "@typechain/hardhat": "^2.0.2",
     "@types/chai": "^4.2.14",

--- a/test/integration/batcher/WrapOnlyBatcherIntegration.test.ts
+++ b/test/integration/batcher/WrapOnlyBatcherIntegration.test.ts
@@ -19,7 +19,7 @@ describe('WrapOnlyBatcher', () => {
       proto.dsu.address,
       proto.usdc.address,
     )
-    await batcher.setPendingOwner(proto.timelock.address)
+    await batcher.updatePendingOwner(proto.timelock.address)
     reserveImpersonator = await impersonate.impersonateWithBalance(proto.reserve.address, utils.parseEther('10'))
   })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -72,10 +72,10 @@
   resolved "https://registry.yarnpkg.com/@ensdomains/resolver/-/resolver-0.2.4.tgz#c10fe28bf5efbf49bff4666d909aed0265efbc89"
   integrity sha512-bvaTH34PMCbv6anRa9I/0zjLJgY4EuznbEMgbV77JBCQ9KNC46rzi0avuxpOfu+xDjPEtSFGqVEOr5GlUSGudA==
 
-"@equilibria/root@0.0.2":
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/@equilibria/root/-/root-0.0.2.tgz#a96bcfadfc83b62898c2b85ba55a1a1729f4f53c"
-  integrity sha512-NRgCBPaoMYirLWoosGuVoRlMwWsxSXyFSzepXRLLN5I47zY4FGY2dyqMiW/EHGRCWNJG8bBbWMIgqRSPV2rULQ==
+"@equilibria/root@0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@equilibria/root/-/root-0.1.1.tgz#19e8a51c691ef0fa979431e6d0de1f4dfde3b6f5"
+  integrity sha512-bYwZ3xncK6cTTZ+0GWsV+zQpBzREuMoAdDqWTt9CEHhx/zRxalDSdoDPQn1Wcu2LxrSZRX+akZHVPVJ6eiCzfA==
 
 "@eslint/eslintrc@^0.4.3":
   version "0.4.3"
@@ -975,10 +975,10 @@
     "@types/sinon-chai" "^3.2.3"
     "@types/web3" "1.0.19"
 
-"@openzeppelin/contracts@4.4.1":
-  version "4.4.1"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.4.1.tgz#3382db2cd83ab565ed9626765e7da92944b45de8"
-  integrity sha512-o+pHCf/yMLSlV5MkDQEzEQL402i6SoRnktru+0rdSxVEFZcTzzGhZCAtZjUFyKGazMSv1TilzMg+RbED1N8XHQ==
+"@openzeppelin/contracts@4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.5.0.tgz#3fd75d57de172b3743cdfc1206883f56430409cc"
+  integrity sha512-fdkzKPYMjrRiPK6K4y64e6GzULR7R7RwxSigHS8DDp7aWDeoReqsQI+cxHV1UuhAqX69L1lAaWDxenfP+xiqzA==
 
 "@resolver-engine/core@^0.3.3":
   version "0.3.3"


### PR DESCRIPTION
- Bumps `root` to `v.0.1.1`
- Bumps Solidity to `v0.8.13`
- Bumps OZ to `v4.5.0`
- Bumps `emptyset-batcher` to `v0.0.2`