### PR TITLE
[Update] Dependency versions

### DIFF
--- a/contracts/batcher/Batcher.sol
+++ b/contracts/batcher/Batcher.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.13;
+pragma solidity ^0.8.13;
 
 import "@equilibria/root/number/types/UFixed18.sol";
 import "@equilibria/root/token/types/Token18.sol";

--- a/contracts/interfaces/IBatcher.sol
+++ b/contracts/interfaces/IBatcher.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: Apache-2.0
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.13;
 
 import "@equilibria/root/number/types/UFixed18.sol";
 

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@equilibria/emptyset-batcher",
   "description": "Batch wrapping contracts for the Empty Set protocol.",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "files": [
     "/interfaces/**/*.sol",
     "/batcher/Batcher.sol"
@@ -21,5 +21,9 @@
   "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/equilibria-xyz/emptyset-batcher/issues"
+  },
+  "dependencies": {
+    "@openzeppelin/root": "0.1.5",
+    "@openzeppelin/contracts": "4.6.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "emptyset-wrapper",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -25,14 +25,14 @@
   "license": "APACHE-2.0",
   "devDependencies": {
     "@codechecks/client": "^0.1.10",
-    "@equilibria/root": "0.1.1",
+    "@equilibria/root": "0.1.5",
     "@ethersproject/abi": "^5.3.1",
     "@ethersproject/bytes": "^5.0.0",
     "@ethersproject/providers": "^5.3.1",
     "@nomiclabs/hardhat-ethers": "^2.0.1",
     "@nomiclabs/hardhat-etherscan": "^2.1.1",
     "@nomiclabs/hardhat-waffle": "^2.0.0",
-    "@openzeppelin/contracts": "4.5.0",
+    "@openzeppelin/contracts": "4.6.0",
     "@typechain/ethers-v5": "^7.0.1",
     "@typechain/hardhat": "^2.0.2",
     "@types/chai": "^4.2.14",

--- a/yarn.lock
+++ b/yarn.lock
@@ -72,10 +72,12 @@
   resolved "https://registry.yarnpkg.com/@ensdomains/resolver/-/resolver-0.2.4.tgz#c10fe28bf5efbf49bff4666d909aed0265efbc89"
   integrity sha512-bvaTH34PMCbv6anRa9I/0zjLJgY4EuznbEMgbV77JBCQ9KNC46rzi0avuxpOfu+xDjPEtSFGqVEOr5GlUSGudA==
 
-"@equilibria/root@0.1.1":
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/@equilibria/root/-/root-0.1.1.tgz#19e8a51c691ef0fa979431e6d0de1f4dfde3b6f5"
-  integrity sha512-bYwZ3xncK6cTTZ+0GWsV+zQpBzREuMoAdDqWTt9CEHhx/zRxalDSdoDPQn1Wcu2LxrSZRX+akZHVPVJ6eiCzfA==
+"@equilibria/root@0.1.5":
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/@equilibria/root/-/root-0.1.5.tgz#f9fb606fed2d0f3d7426d37d7bc45f176b26f80e"
+  integrity sha512-K++w/DyJktl58dQe4P78K0dzduQe1CKPU+Z52DsISik99FN7OwdMTQZt1APpJfovfZh0focsHMnTiRpLmIti7Q==
+  dependencies:
+    "@openzeppelin/contracts" "4.6.0"
 
 "@eslint/eslintrc@^0.4.3":
   version "0.4.3"
@@ -975,10 +977,10 @@
     "@types/sinon-chai" "^3.2.3"
     "@types/web3" "1.0.19"
 
-"@openzeppelin/contracts@4.5.0":
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.5.0.tgz#3fd75d57de172b3743cdfc1206883f56430409cc"
-  integrity sha512-fdkzKPYMjrRiPK6K4y64e6GzULR7R7RwxSigHS8DDp7aWDeoReqsQI+cxHV1UuhAqX69L1lAaWDxenfP+xiqzA==
+"@openzeppelin/contracts@4.6.0":
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.6.0.tgz#c91cf64bc27f573836dba4122758b4743418c1b3"
+  integrity sha512-8vi4d50NNya/bQqCmaVzvHNmwHvS0OBKb7HNtuNwEE3scXWrP31fKQoGxNMT+KbzmrNZzatE3QK5p2gFONI/hg==
 
 "@resolver-engine/core@^0.3.3":
   version "0.3.3"


### PR DESCRIPTION
- Bumps OZ to `v4.6.0`
- Bumps root to `v0.1.5`
- Bumps emptyset-batcher to `v0.0.3`
- Moves interfaces and abstract contracts to `pragma ^0.8.13`
- Uses `dependency` instead of `peerDependency` in internal library `package.json`