### PR TITLE
Upgrade Solidity to 0.8.17

### DIFF
--- a/contracts/batcher/TwoWayBatcher.sol
+++ b/contracts/batcher/TwoWayBatcher.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.13;
+pragma solidity 0.8.17;
 
 import "@equilibria/root/number/types/UFixed18.sol";
 import "@equilibria/root/token/types/Token18.sol";

--- a/contracts/batcher/WrapOnlyBatcher.sol
+++ b/contracts/batcher/WrapOnlyBatcher.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.13;
+pragma solidity 0.8.17;
 
 import "@equilibria/root/number/types/UFixed18.sol";
 import "@equilibria/root/token/types/Token18.sol";

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -96,7 +96,7 @@ const config: HardhatUserConfig = {
   solidity: {
     compilers: [
       {
-        version: '0.8.13',
+        version: '0.8.17',
         settings: {
           optimizer: {
             enabled: false,


### PR DESCRIPTION
Opted to go straight to 0.8.17 as `16` and `17` both contain important bugfixes [[0](https://blog.soliditylang.org/2022/08/08/solidity-0.8.16-release-announcement/)][[1](https://blog.soliditylang.org/2022/09/08/solidity-0.8.17-release-announcement/#:~:text=17%20Release%20Announcement,-Posted%20by%20Solidity&text=Solidity%20v0.,all%20files%20in%20a%20project.)]